### PR TITLE
Added ENRC #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ and other packages (see below).
 Furthermore, it contains wrappers for [pyclustering](https://pyclustering.github.io/) implementations.
 
 ## Installation
+
+### For Users
+
 The package can be installed directly from git by executing:
 
 `sudo pip3 install git+https://github.com/collinleiber/ClusPy.git`
@@ -24,6 +27,26 @@ The package can be installed directly from git by executing:
 Alternatively, clone the repository, go to the directory and execute:
 
 `sudo python setup.py install`
+
+If you have no sudo rights you can use:
+
+`python setup.py install --prefix ~/.local`
+
+### For Developers
+
+Clone the repository, go to the directory and do the following.
+
+Install package locally and compile C files:
+
+`python setup.py install --prefix ~/.local`
+
+Copy compiled C files to correct file location:
+
+`python setup.py build_ext --inplace`
+
+Remove cluspy via pip to avoid ambiguities during development, e.g., when changing files in the code:
+
+`pip3 uninstall cluspy`
 
 ## Components
 
@@ -56,6 +79,7 @@ Alternatively, clone the repository, go to the directory and execute:
     - VaDE
     - DipDECK
     - DipEncoder
+    - ENRC
     
 ### Other implementations
 
@@ -185,7 +209,7 @@ datasets = [
     preprocess_params=[{"dims":0.9}, {}],ignore_algorithms=["pdipmeans"]),
     EvaluationDataset("Pendigits_pca", data=load_pendigits, preprocess_methods=reduce_dimensionality, preprocess_params={"dims":0.9}),
     EvaluationDataset("Wine", data=load_wine),
-    EvaluationDataset("Wine_znorn", data=load_wine, preprocess_methods=znorm)]
+    EvaluationDataset("Wine_znorm", data=load_wine, preprocess_methods=znorm)]
 
 algorithms = [
     EvaluationAlgorithm("SubKmeans", SubKmeans, {"n_clusters": None}),

--- a/cluspy/deep/__init__.py
+++ b/cluspy/deep/__init__.py
@@ -7,6 +7,10 @@ from .enrc import ENRC
 from .simple_autoencoder import Simple_Autoencoder
 from .stacked_autoencoder import Stacked_Autoencoder
 from .flexible_autoencoder import FlexibleAutoencoder
+from ._utils import get_dataloader
+from ._utils import encode_batchwise
+from ._utils import predict_batchwise
+
 
 __all__ = ['DEC',
            'IDEC',
@@ -17,4 +21,7 @@ __all__ = ['DEC',
            'Simple_Autoencoder',
            'FlexibleAutoencoder',
            'Stacked_Autoencoder',
-           'DipEncoder']
+           'DipEncoder',
+           'get_dataloader',
+           'encode_batchwise',
+           'predict_batchwise']

--- a/cluspy/deep/_utils.py
+++ b/cluspy/deep/_utils.py
@@ -113,7 +113,9 @@ def get_dataloader(X, batch_size, shuffle=True, drop_last=False, additional_inpu
     The final dataloader
     """
     assert type(additional_inputs) is list, "additional_input should be of type list."
-    dataset_input = [torch.from_numpy(X).float()]
+    if type(X) is np.ndarray:
+        X = torch.from_numpy(X).float()
+    dataset_input = [X]
     for input in additional_inputs:
         if type(input) is np.ndarray:
             input = torch.from_numpy(input).float()


### PR DESCRIPTION
 Add ENRC (Issue #13). @collinleiber  please check pull request. 

As I am using the TensorDataSet everywhere I had to reimplement 
```
def _encode_batchwise(dataloader, model, device):
    embeddings = []
    for batch in dataloader:
        batch_data = batch[0].to(device)
        embeddings.append(model.encode(batch_data).detach().cpu())
    return torch.cat(embeddings, dim=0).numpy()
```
 
which can handle lists as well. One could leave it that way or update the encode_batchwise function in deep/_utils.py to check whether batch is a list or a tensor to make it more general.  Please also  take a look at the TODO in deep/enrc.py. 